### PR TITLE
Update postgresql.conf template to only select wal_keep_segments up to postgres 13

### DIFF
--- a/ansible/roles/debops.postgresql_server/templates/etc/postgresql/postgresql.conf.j2
+++ b/ansible/roles/debops.postgresql_server/templates/etc/postgresql/postgresql.conf.j2
@@ -218,7 +218,12 @@ archive_timeout = {{ item.archive_timeout | d('0') }}
 
 # Set these on the master and on any standby that will send replication data
 max_wal_senders = {{ item.max_wal_senders | d('0') }}
+{% if (item.version | d(postgresql_server__version)) is version_compare('13','<') %}
 wal_keep_segments = {{ item.wal_keep_segments | d('0') }}
+{% endif %}
+{% if (item.version | d(postgresql_server__version)) is version_compare('13','>=') %}
+wal_keep_size = {{ item.wal_keep_size | d('0') }}
+{% endif %}
 {% if (item.version | d(postgresql_server__version)) is version_compare('9.1','>') %}
 wal_sender_timeout = {{ item.wal_sender_timeout | d('60s') }}
 {% endif %}


### PR DESCRIPTION
Postgresql 13 renamed `wal_keep_segments` to `wal_keep_size`. Having `wal_keep_segments` in `postgresql.conf` prevents pg13 from starting.

(cherry picked from commit b9532803f5d2ece491c62dd96764cb9533cb9948)