### PR TITLE
[debops.ifupdown] Ensure that /run/network/ exists

### DIFF
--- a/ansible/roles/debops.ifupdown/tasks/divert_interfaces.yml
+++ b/ansible/roles/debops.ifupdown/tasks/divert_interfaces.yml
@@ -30,6 +30,14 @@
     mode: '0644'
   register: ifupdown__register_main_config
 
+- name: Ensure that runtime directory exists
+  file:
+    path: '/run/network'
+    state: 'directory'
+    mode: '0755'
+  when: (ifupdown__register_divert is changed or
+         ifupdown__register_main_config is changed)
+
 - name: Request entire network reconfiguration
   copy:
     content: 'init'


### PR DESCRIPTION
The '/run/network/' directory might not be present on hosts that don't
use ifupdown as their network configuration manager (for example recent
Ubuntu releases). Ensuring that the directory exists allows the role to
tell the ifup reconfiguration script to reconfigure all network
interfaces during initial setup.