### PR TITLE
[ansible_plugins] Fix 'ignore' state handling

### DIFF
--- a/ansible/roles/debops.ansible_plugins/filter_plugins/debops_filter_plugins.py
+++ b/ansible/roles/debops.ansible_plugins/filter_plugins/debops_filter_plugins.py
@@ -189,87 +189,91 @@ def parse_kv_config(*args, **kwargs):
             element = {name: element}
 
         if isinstance(element, dict):
-            if (any(x in [name] for x in element) and
-                    element.get('state', 'present') != 'ignore'):
+            if any(x in [name] for x in element):
 
-                param_name = element.get(name)
+                if element.get('state', 'present') != 'ignore':
 
-                if element.get('state', 'present') == 'append':
+                    param_name = element.get(name)
 
-                    # In append mode, don't create new config entries
-                    if (parsed_config.get(param_name, {})
-                            .get('state', 'present') == 'init'):
-                        continue
+                    if element.get('state', 'present') == 'append':
 
-                current_param = (parsed_config[param_name].copy()
-                                 if param_name in parsed_config
-                                 else {})
+                        # In append mode, don't create new config entries
+                        if (parsed_config.get(param_name, {})
+                                .get('state', 'present') == 'init'):
+                            continue
 
-                if element.get('state', 'present') == 'append':
-                    current_param['state'] = current_param.get(
-                            'state', 'present')
-                else:
-                    current_param['state'] = (
-                        element.get('state', current_param.get(
-                            'state', 'present')))
+                    current_param = (parsed_config[param_name].copy()
+                                     if param_name in parsed_config
+                                     else {})
 
-                if (current_param['state'] == 'init' and
-                    (element.get('state', 'present') != 'init' and
-                        _check_if_key_in_nested_dict(
-                        'value', current_param))):
-                    current_param['state'] = 'present'
+                    if element.get('state', 'present') == 'append':
+                        current_param['state'] = current_param.get(
+                                'state', 'present')
+                    else:
+                        current_param['state'] = (
+                            element.get('state', current_param.get(
+                                'state', 'present')))
 
-                current_param.update({
-                    name: param_name,  # in case of a new entry
-                    'id': int(current_param.get('id', (element_index * 10))),
-                    'weight': int(current_param.get('weight', 0)),
-                    'separator': element.get('separator',
-                                             current_param.get('separator',
-                                                               False)),
-                    'section': element.get('section',
-                                           current_param.get('section',
-                                                             'unknown'))
-                })
+                    if (current_param['state'] == 'init' and
+                        (element.get('state', 'present') != 'init' and
+                            _check_if_key_in_nested_dict(
+                            'value', current_param))):
+                        current_param['state'] = 'present'
 
-                _handle_copy_id_from(parsed_config, element, current_param)
-                _handle_weight(element, current_param)
+                    current_param.update({
+                        name: param_name,  # in case of a new entry
+                        'id': int(current_param.get('id',
+                                                    (element_index * 10))),
+                        'weight': int(current_param.get('weight', 0)),
+                        'separator': element.get('separator',
+                                                 current_param.get('separator',
+                                                                   False)),
+                        'section': element.get('section',
+                                               current_param.get('section',
+                                                                 'unknown'))
+                    })
 
-                current_param['real_weight'] = _get_real_weight(current_param)
+                    _handle_copy_id_from(parsed_config, element, current_param)
+                    _handle_weight(element, current_param)
 
-                _parse_kv_value(current_param, element,
-                                current_param.get('id'))
+                    current_param['real_weight'] = (
+                            _get_real_weight(current_param))
 
-                if 'option' in element:
-                    current_param['option'] = element.get('option')
+                    _parse_kv_value(current_param, element,
+                                    current_param.get('id'))
 
-                if 'comment' in element:
-                    current_param['comment'] = element.get('comment')
+                    if 'option' in element:
+                        current_param['option'] = element.get('option')
 
-                merge_keys = []
-                if isinstance(kwargs.get('merge_keys'), list):
-                    merge_keys.extend(kwargs.get('merge_keys'))
+                    if 'comment' in element:
+                        current_param['comment'] = element.get('comment')
 
-                if 'options' not in merge_keys:
-                    merge_keys.append('options')
+                    merge_keys = []
+                    if isinstance(kwargs.get('merge_keys'), list):
+                        merge_keys.extend(kwargs.get('merge_keys'))
 
-                for key_name in merge_keys:
-                    if key_name in element:
-                        current_options = current_param.get(key_name, [])
-                        current_param[key_name] = parse_kv_config(
-                            current_options + element.get(key_name),
-                            merge_keys=merge_keys)
+                    if 'options' not in merge_keys:
+                        merge_keys.append('options')
 
-                # Include any unknown keys
-                for unknown_key in element.keys():
-                    if (unknown_key not in merge_keys
-                        and unknown_key not in [name, 'state', 'id',
-                                                'weight', 'real_weight',
-                                                'separator', 'value',
-                                                'comment', 'option',
-                                                'section']):
-                        current_param[unknown_key] = element.get(unknown_key)
+                    for key_name in merge_keys:
+                        if key_name in element:
+                            current_options = current_param.get(key_name, [])
+                            current_param[key_name] = parse_kv_config(
+                                current_options + element.get(key_name),
+                                merge_keys=merge_keys)
 
-                parsed_config.update({param_name: current_param})
+                    # Include any unknown keys
+                    for unknown_key in element.keys():
+                        if (unknown_key not in merge_keys
+                            and unknown_key not in [name, 'state', 'id',
+                                                    'weight', 'real_weight',
+                                                    'separator', 'value',
+                                                    'comment', 'option',
+                                                    'section']):
+                            current_param[unknown_key] = (
+                                    element.get(unknown_key))
+
+                    parsed_config.update({param_name: current_param})
 
             # These parameters are special and should not be interpreted
             # directly as configuration options


### PR DESCRIPTION
The configuration entries which used YAML dictionary syntax and were
marked with 'ignore' state, were incorrectly parsed by the filter
plugin, returning bad configuration data.

This patch fixes this by separating the check for the YAML dictionary
format and for the 'ignore' state into separate 'if' statements.

(cherry picked from commit aee081798adc55ef92a9194fcc9e8562c783b098)