### PR TITLE
[debops.nginx] Allow logging to socket

### DIFF
--- a/ansible/roles/debops.nginx/defaults/main.yml
+++ b/ansible/roles/debops.nginx/defaults/main.yml
@@ -165,8 +165,24 @@ nginx_run_path: '/run'
 # .. envvar:: nginx_log_path [[[
 #
 # Directory where :program:`nginx` log files are stored.
-nginx_log_path: '/var/log/nginx'
+# Socket where :program:`nginx` sends logs to, if nginx_log_to_syslog is true.
+# A socket can be unix:/path/to/socket or ipaddress:port
+nginx_log_path: '{{ "unix:/dev/log" if nginx_log_to_syslog else "/var/log/nginx" }}'
 
+                                                                   # ]]]
+# .. envvar:: nginx_log_to_syslog [[[
+#
+# If this variable is true, :program:`nginx` logs to the socket stored
+# in `nginx_log_path`.
+nginx_log_to_syslog: False
+
+                                                                   # ]]]
+# .. envvar:: nginx_syslog_config [[[
+#
+# Examples from nginx documentation are:
+# `nohostname`
+# `facility=local7,tag=nginx,severity=info`
+nginx_syslog_config: 'nohostname'
                                                                    # ]]]
 # ---- Phusion Passenger support ----
 

--- a/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/nginx.conf.j2
@@ -9,7 +9,15 @@ pid {{ nginx_run_path }}/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 # Default error_log
+{% set nginx_tpl_syslog_config = '' %}
+{% if nginx_syslog_config is defined %}
+{%     set nginx_tpl_syslog_config = ',' + nginx_syslog_config %}
+{% endif %}
+{% if nginx_log_to_syslog %}
+error_log syslog:server={{ nginx_log_path }}{{ nginx_tpl_syslog_config }};
+{% else %}
 error_log {{ nginx_http_error_log | default(nginx_log_path + '/error.log') }};
+{% endif %}
 
 # Nicenness, from 20 (nice) to -20 (not nice)
 worker_priority {{ nginx_worker_priority | default('0') }};
@@ -54,8 +62,13 @@ http {
 {%          set nginx_tpl_access_log_format = ' ' +  nginx_access_log_format %}
 {%      endif %}
         # Logging
+{% if nginx_log_to_syslog %}
+        access_log syslog:server={{ nginx_log_path }}{{ nginx_tpl_syslog_config }}{{ nginx_tpl_access_log_format }};
+        error_log  syslog:server={{ nginx_log_path }}{{ nginx_tpl_syslog_config }};
+{% else %}
         access_log {{ nginx_http_access_log | default(nginx_log_path + '/access.log' + nginx_tpl_access_log_format) }};
         error_log  {{ nginx_http_error_log  | default(nginx_log_path + '/error.log')  }};
+{% endif %}
 {% endblock %}
 
         add_header X-Clacks-Overhead "GNU Terry Pratchett";

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -213,13 +213,27 @@
 {%             elif nginx_access_log_format is defined                              %}
 {%                 set nginx_tpl_access_log_format = ' ' +  nginx_access_log_format %}
 {%             endif                                                                %}
+{%             set nginx_tpl_syslog_config = ''                                     %}
+{%             if item.syslog_config is defined                                     %}
+{%                 set nginx_tpl_syslog_config = ',' + item.syslog_config           %}
+{%             elif nginx_syslog_config is defined                                  %}
+{%                 set nginx_tpl_syslog_config = ',' + nginx_syslog_config          %}
+{%             endif                                                                %}
 {%             if item.access_log_enabled|d(True) | bool %}
+{%                 if (item.log_to_syslog | d(nginx_log_to_syslog))                 %}
+        access_log syslog:server={{ item.log_path | d(nginx_log_path)}}{{ nginx_tpl_syslog_config }}{{ nginx_tpl_access_log_format }};
+{%                 else                                                             %}
         access_log {{ (item.log_path | d(nginx_log_path)) + '/' + item.access_log | d(item.filename | d(item.name if item.name is string else item.name[0]) + '_access') }}.log{{ nginx_tpl_access_log_format }};
+{%                 endif                                                            %}
 {%             else %}
         access_log off;
 {%             endif %}
 {%             if item.error_log_enabled|d(True) | bool %}
+{%                 if (item.log_to_syslog | d(nginx_log_to_syslog))                 %}
+        error_log  syslog:server={{ item.log_path | d(nginx_log_path) }}{{ nginx_tpl_syslog_config }};
+{%                 else                                                             %}
         error_log {{ (item.log_path | d(nginx_log_path)) + '/' + item.error_log | d(item.filename | d(item.name if item.name is string else item.name[0]) + '_error') }}.log;
+{%                 endif                                                            %}
 {%             else %}
         error_log off;
 {%             endif %}


### PR DESCRIPTION
This changes allow sending logs to a local or remote socket, eg.
/dev/log or a remote syslog server.