### PR TITLE
[dovecot] Add ability to list users using doveadm

### DIFF
--- a/ansible/roles/dovecot/defaults/main.yml
+++ b/ansible/roles/dovecot/defaults/main.yml
@@ -1219,6 +1219,26 @@ dovecot__ldap_user_filter: '(&
                               )
                             )'
 
+# .. envvar:: dovecot__ldap_user_list_filter [[[
+#
+# The LDAP filter used to look list user accounts in the directory. This allows
+# commands like :command:`doveadm users '*'` or :command:`doveadm purge -A` to
+# work.
+# See :ref:`ldap__ref_admin` for more information.
+dovecot__ldap_user_list_filter: '(&
+                              (objectClass=mailRecipient)
+                              (|
+                                (authorizedService=all)
+                                (authorizedService=mail:access)
+                              )
+                            )'
+
+# .. envvar:: dovecot__ldap_user_list_filter_attribute [[[
+#
+# The attribute used by :ref:`dovecot__ldap_user_list_filter_attribute` as
+# the identifier of the user.
+# See :ref:`ldap__ref_admin` for more information.
+dovecot__ldap_user_list_filter_attribute: 'mail'
                                                                    # ]]]
 # .. envvar:: dovecot__ldap_quota_attribute [[[
 #

--- a/ansible/roles/dovecot/templates/etc/dovecot/dovecot-ldap-userdb.conf.j2
+++ b/ansible/roles/dovecot/templates/etc/dovecot/dovecot-ldap-userdb.conf.j2
@@ -36,3 +36,5 @@ user_attrs = \
     mailExpungeTrash={{ dovecot__ldap_trash_field }}
 
 user_filter = {{ dovecot__ldap_user_filter }}
+iterate_filter= {{ dovecot__ldap_user_list_filter }}
+iterate_attrs= {{ dovecot__ldap_user_list_filter_attribute }}=user


### PR DESCRIPTION
Before this change, dovecot could only check if users existed, but it could not iterate over them. That is, the following would not work

    doveadm user '*'

Nor any command that takes `-A` (all-users), like so:

    doveadm purge -A

With this change, a new default query is added that works like the existing default queries. Instead of searching for a user, it lists them however.