### PR TITLE
(NetBox) Allow custom LDAP attributes

### DIFF
--- a/ansible/roles/netbox/defaults/main.yml
+++ b/ansible/roles/netbox/defaults/main.yml
@@ -511,6 +511,24 @@ netbox__ldap_object_ownerdn: '{{ ([ netbox__ldap_object_owner_rdn, netbox__ldap_
                                     + netbox__ldap_base_dn) | join(",") }}'
                                                                    # ]]]
                                                                    # ]]]
+# .. envvar:: netbox__ldap_attr_firstname [[[
+#
+# The attribute of the LDAP object that shows the users first name.
+netbox__ldap_attr_firstname: 'cn'
+
+                                                                   # ]]]
+# .. envvar:: netbox__ldap_attr_sn [[[
+#
+# The attribute of the LDAP object that shows the users last name.
+netbox__ldap_attr_sn: 'sn'
+
+                                                                   # ]]]
+# .. envvar:: netbox__ldap_attr_mail [[[
+#
+# The attribute of the LDAP object that shows the users email address.
+netbox__ldap_attr_mail: 'mailAddress'
+
+                                                                   # ]]]
 # LDAP connection options [[[
 # ---------------------------
 

--- a/ansible/roles/netbox/templates/usr/local/lib/netbox/ldap_config.py.j2
+++ b/ansible/roles/netbox/templates/usr/local/lib/netbox/ldap_config.py.j2
@@ -84,7 +84,7 @@ AUTH_LDAP_CACHE_TIMEOUT = int(environ.get('AUTH_LDAP_CACHE_TIMEOUT', 3600))
 
 # Populate the Django user from the LDAP directory.
 AUTH_LDAP_USER_ATTR_MAP = {
-    "first_name": environ.get('AUTH_LDAP_ATTR_FIRSTNAME', 'givenName'),
-    "last_name": environ.get('AUTH_LDAP_ATTR_LASTNAME', 'sn'),
-    "email": environ.get('AUTH_LDAP_ATTR_MAIL', 'mailAddress')
+    "first_name": environ.get('AUTH_LDAP_ATTR_FIRSTNAME', '{{ netbox__ldap_attr_firstname }}'),
+    "last_name": environ.get('AUTH_LDAP_ATTR_LASTNAME', '{{ netbox__ldap_attr_sn }}'),
+    "email": environ.get('AUTH_LDAP_ATTR_MAIL', '{{ netbox__ldap_attr_mail }}')
 }


### PR DESCRIPTION
Allow NetBox to populate user profiles with custom LDAP attributes defined in Ansible.

The default in NetBox is:
```
netbox__ldap_attr_firstname: 'cn'
netbox__ldap_attr_sn: 'sn'
netbox__ldap_attr_mail: 'mailAddress'
```
But our LDAP has a `cn` including givenName + surname, and we get duplicated entries in the name field in NetBox. We'd want to use custom LDAP attributes instead.