### PR TITLE
(NetBox) Check the superuser account state before creating it

### DIFF
--- a/ansible/roles/netbox/tasks/main.yml
+++ b/ansible/roles/netbox/tasks/main.yml
@@ -268,6 +268,24 @@
          not netbox__primary|bool)
   changed_when: false
 
+- name: Check if Django superuser account exists
+  # In case of an upgrade (with DB migrations), the superuser will
+  # be existent but the createsuperuser command will run anyway (and fails).
+  # So we check if it exist beforehand and only run the create command if needed.
+  environment:
+    DJANGO_SUPERUSER_PASSWORD: '{{ netbox__superuser_password }}'
+  django_manage:
+    command: shell -c 'import sys; from django.contrib.auth.models import User; print(User.objects.filter(username="{{ netbox__superuser_name }}").count())'
+    app_path: '{{ netbox__git_checkout + "/netbox" }}'
+    virtualenv: '{{ netbox__virtualenv }}'
+  become: True
+  become_user: '{{ netbox__user }}'
+  when: netbox__primary|bool
+  no_log: '{{ debops__no_log | d(True) }}'
+  register: netbox__check_superuser
+  ignore_errors: true
+  changed_when: false
+
 - name: Create Django superuser account
   environment:
     DJANGO_SUPERUSER_PASSWORD: '{{ netbox__superuser_password }}'
@@ -279,7 +297,7 @@
   become_user: '{{ netbox__user }}'
   when: (netbox__primary|bool and
          not netbox__register_installed.stat.exists|bool and
-         not netbox__register_migration.stdout is search('No migrations to apply.'))
+         netbox__check_superuser.out | trim == "0")
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate systemd service unit


### PR DESCRIPTION
In case of NetBox version updates that include database migrations, it happens that all `when` conditionals are `True` and debops tries to create the Django superuser account again. Since this task is not idempotent, it will just fail due to `user already exists`. 

With this check, we ensure it will only run the `createsuperuser` task, if the defined admin user is not present.