### PR TITLE
Allow enabling/disabling of LDPA always update user option

### DIFF
--- a/ansible/roles/netbox/defaults/main.yml
+++ b/ansible/roles/netbox/defaults/main.yml
@@ -510,7 +510,15 @@ netbox__ldap_object_owner_rdn: 'uid={{ lookup("env", "USER") }}'
 netbox__ldap_object_ownerdn: '{{ ([ netbox__ldap_object_owner_rdn, netbox__ldap_people_rdn ]
                                     + netbox__ldap_base_dn) | join(",") }}'
                                                                    # ]]]
+
+# .. envvar:: netbox__ldap_always_update_user [[[
+#
+# Always update users in database upon login.
+# Needs False for secondary nodes with read-only Databse.
+netbox__ldap_always_update_user: True
                                                                    # ]]]
+                                                                   # ]]]
+
 # LDAP connection options [[[
 # ---------------------------
 

--- a/ansible/roles/netbox/defaults/main.yml
+++ b/ansible/roles/netbox/defaults/main.yml
@@ -514,7 +514,7 @@ netbox__ldap_object_ownerdn: '{{ ([ netbox__ldap_object_owner_rdn, netbox__ldap_
 # .. envvar:: netbox__ldap_always_update_user [[[
 #
 # Always update users in database upon login.
-# Needs False for secondary nodes with read-only Databse.
+# Needs False for secondary nodes with read-only Database.
 netbox__ldap_always_update_user: True
                                                                    # ]]]
                                                                    # ]]]

--- a/ansible/roles/netbox/templates/usr/local/lib/netbox/ldap_config.py.j2
+++ b/ansible/roles/netbox/templates/usr/local/lib/netbox/ldap_config.py.j2
@@ -88,3 +88,6 @@ AUTH_LDAP_USER_ATTR_MAP = {
     "last_name": environ.get('AUTH_LDAP_ATTR_LASTNAME', 'sn'),
     "email": environ.get('AUTH_LDAP_ATTR_MAIL', 'mailAddress')
 }
+
+# Set to False to allow LDAP logins on secondary (read-only DB) instances
+AUTH_LDAP_ALWAYS_UPDATE_USER = {{ netbox__ldap_always_update_user }}


### PR DESCRIPTION
Allows DebOps to configure the config parameter `netbox__ldap_always_update_user` in NetBox's `ldap_config.py` file.

`group_vars` will get:
```
## Fix LDAP login on secondary site
netbox__ldap_always_update_user: '{{ "False" if inventory_hostname in groups["netbox-standby"] else "True" }}'
```