### PR TITLE
[reprepro] Add ability to disable GPG snapshot creation

### DIFF
--- a/ansible/roles/reprepro/defaults/main.yml
+++ b/ansible/roles/reprepro/defaults/main.yml
@@ -165,6 +165,16 @@ reprepro__gpg_snapshot_name: 'gnupg.tar'
 # be archived.
 reprepro__gpg_snapshot_path: '{{ secret + "/reprepro/snapshots/" + inventory_hostname }}'
 
+
+# .. envvar:: reprepro__gpg_snapshot_keep [[[
+#
+# Wether gpg snapshots should be created and downloaded to the Ansible
+# controller. This should only be disabled the backup is kept another way.
+#
+# When disabling the snapshot, after using them, the old gnupg.tar files should
+# be removed, otherwise the role might revert to an old snapshot state.
+reprepro__gpg_snapshot_keep: true
+
                                                                    # ]]]
 # .. envvar:: reprepro__gpg_key_type [[[
 #

--- a/ansible/roles/reprepro/tasks/configure_gnupg.yml
+++ b/ansible/roles/reprepro/tasks/configure_gnupg.yml
@@ -71,13 +71,16 @@
     group: '{{ reprepro__group }}'
     mode: '0600'
   register: reprepro__register_gpg_archive
+  when: reprepro__gpg_snapshot_keep
 
 - name: Upload ~/.gnupg archive to Ansible Controller
   ansible.builtin.fetch:  # noqa no-handler
     src: '{{ reprepro__home + "/" + reprepro__gpg_snapshot_name }}'
     dest: '{{ reprepro__gpg_snapshot_path + "/" + reprepro__gpg_snapshot_name }}'
     flat: True
-  when: reprepro__register_gpg_archive is changed
+  when:
+    - reprepro__gpg_snapshot_keep
+    - reprepro__register_gpg_archive is changed
 
 - name: Remove old automatic signing key
   ansible.builtin.file:  # noqa no-handler


### PR DESCRIPTION
Under some circumstances those are not desirable:

- When the backup is done another way.
- If one does not want them on the Ansible controller.
- If the secret directory is not used.