### PR TITLE
[opendkim] Add ability to manage dkim keys externally

### DIFF
--- a/ansible/roles/opendkim/defaults/main.yml
+++ b/ansible/roles/opendkim/defaults/main.yml
@@ -154,6 +154,13 @@ opendkim__combined_keys: '{{ opendkim__default_keys
                              + opendkim__group_keys
                              + opendkim__host_keys }}'
                                                                    # ]]]
+# .. envvar:: opendkim__manage_keys [[[
+#
+# True if opendkim should generate and place the domainkey files. This option
+# is useful if the domainkey files are managed by another role.
+opendkim__manage_keys: True
+
+                                                                   # ]]]
                                                                    # ]]]
 # DKIM Signing Table [[[
 # ----------------------

--- a/ansible/roles/opendkim/tasks/main.yml
+++ b/ansible/roles/opendkim/tasks/main.yml
@@ -108,6 +108,7 @@
   become: False
   delegate_to: 'localhost'
   run_once: True
+  when: opendkim__manage_keys | default(True)
 
 - name: Generate DomainKeys on Ansible Controller
   community.crypto.openssl_privatekey:
@@ -123,6 +124,7 @@
   become: False
   delegate_to: 'localhost'
   no_log: '{{ debops__no_log | d(True) }}'
+  when: opendkim__manage_keys | default(True)
 
 - name: Remove DomainKeys from hosts when requested
   ansible.builtin.file:
@@ -131,7 +133,9 @@
               + (item.selector | d(item.name | d(item))) + ".pem" }}'
     state: 'absent'
   loop: '{{ q("flattened", opendkim__combined_keys) }}'
-  when: item.state | d('present') == 'absent'
+  when:
+    - item.state | d('present') == 'absent'
+    - opendkim__manage_keys | default(True)
 
 - name: Download DomainKeys from Ansible Controller
   ansible.builtin.copy:
@@ -145,7 +149,9 @@
     group: '{{ opendkim__group }}'
     mode: '0640'
   loop: '{{ q("flattened", opendkim__combined_keys) }}'
-  when: item.state | d('present') != 'absent'
+  when:
+    - item.state | d('present') != 'absent'
+    - opendkim__manage_keys | default(True)
   no_log: '{{ debops__no_log | d(True) }}'
 
 - name: Generate key configuration files


### PR DESCRIPTION
It may be desirable to write these keys using a different mechanism, for example when managing these keys in Vault. With this change, it is possible to disable this specific aspect of debops.opendkim.