### PR TITLE
[ifupdown] Invoke systemctl instead of systemd

### DIFF
--- a/ansible/roles/ifupdown/tasks/ifup_systemd.yml
+++ b/ansible/roles/ifupdown/tasks/ifup_systemd.yml
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 - name: Check systemd version
-  ansible.builtin.shell: set -o nounset -o pipefail -o errexit && systemd --version | head -n 1 | awk '{print $2}'
+  ansible.builtin.shell: set -o nounset -o pipefail -o errexit && systemctl --version | head -n 1 | awk '{print $2}'
   args:
     executable: 'bash'
   register: ifupdown__register_systemd_version


### PR DESCRIPTION
The systemd binary is not meant to be invoked directly [^1] and is no longer in the PATH in Trixie.

[^1]: https://www.freedesktop.org/software/systemd/man/latest/systemd.html